### PR TITLE
ABCブレーキ検出処理における平均値計算を修正しました。

### DIFF
--- a/arduino/funcdecoder2/ABC_detector_tiny1606.c
+++ b/arduino/funcdecoder2/ABC_detector_tiny1606.c
@@ -71,7 +71,7 @@ uint8_t setABCsumRight(uint8_t value) {
 		backValue += ABCsumRight[i];
 	}
 	
-	return (uint8_t)(backValue >> 4);
+	return (uint8_t)(backValue >> 2);
 }
 
 uint8_t setABCsumLeft(uint8_t value) {

--- a/arduino/motordecoder2/ABC_detector_tiny1606.c
+++ b/arduino/motordecoder2/ABC_detector_tiny1606.c
@@ -70,7 +70,7 @@ uint8_t setABCsumRight(uint8_t value) {
 		backValue += ABCsumRight[i];
 	}
 	
-	return (uint8_t)(backValue >> 4);
+	return (uint8_t)(backValue >> 2);
 }
 
 uint8_t setABCsumLeft(uint8_t value) {

--- a/source/source/peripheral/ABC_detector_tiny1606.c
+++ b/source/source/peripheral/ABC_detector_tiny1606.c
@@ -70,7 +70,7 @@ uint8_t setABCsumRight(uint8_t value) {
 		backValue += ABCsumRight[i];
 	}
 	
-	return (uint8_t)(backValue >> 4);
+	return (uint8_t)(backValue >> 2);
 }
 
 uint8_t setABCsumLeft(uint8_t value) {


### PR DESCRIPTION
## 概要
ABCブレーキ検出処理における平均値計算を修正しました。
該当処理では4回分のADCサンプルを加算していますが、従来は `>> 4` により16で割る処理になっていました。 4サンプルの平均値を求める処理であるため、`>> 2` に変更しました。

## 修正内容
- `backValue >> 4` を `backValue >> 2` に変更

## 関連Issue
Fixes #38 

<img width="984" height="1356" alt="CodexによるDebug and Bugfix" src="https://github.com/user-attachments/assets/1064c4db-9158-408c-b73b-80d516e804d2" />
